### PR TITLE
add automatic test for inferences

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+
+name: inference-test
+
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  run-amd64:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Pip setup
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          pip install fastai
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Prepare environment
+        run: |
+          git clone --branch 1.x https://huggingface.co/datasets/ninjalabo/imagenette2-320 md/data/test
+          git clone https://huggingface.co/ninjalabo/resnet18 && cp resnet18/model.pkl md/model.pkl
+          sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Run tests
+        run: python test_all.py amd64

--- a/md/runtime_info.json
+++ b/md/runtime_info.json
@@ -1,0 +1,10 @@
+{
+  "runtime": "tinyruntime",
+  "architecture": "amd64",
+  "image": "",
+  "compression": {
+    "quantization": false,
+    "pruning": 0
+  },
+  "results": {}
+}

--- a/run.sh
+++ b/run.sh
@@ -37,4 +37,5 @@ else
   [ -z "$accuracy" ] && echo "Accuracy is empty."
   [ -z "$speed" ] && echo "Speed is empty."
   [ -z "$model_size" ] && echo "Model size is empty."
+  exit 1
 fi

--- a/test_all.py
+++ b/test_all.py
@@ -1,0 +1,33 @@
+import subprocess
+import json
+import sys
+
+def run_command(command, cwd=None):
+    try:
+        print(f"Running command: {command}")
+        subprocess.run(command, shell=True, cwd=cwd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as e:
+        print(f"Error occurred while running command: {command}")
+        print(e.stderr)
+        exit(1)
+
+def main(architecture):
+    # Python inference
+    run_command("./run.sh run.py md/model.pkl md/data/test")
+
+    # Vanilla C inference
+    run_command("docker run --rm -v $(pwd)/md:/root/md ninjalabo/compiler-export-models")
+    run_command(f"./run.sh {architecture}/run md/model.bin md/data/test/*/*")
+
+    # Quantized C inference 
+    with open('md/runtime_info.json', 'r') as file:
+        data = json.load(file)
+        data['compression']['quantization'] = True
+    with open('md/runtime_info.json', 'w') as file:
+        json.dump(data, file, indent=4)
+    run_command("docker run --rm -v $(pwd)/md:/root/md ninjalabo/compiler-export-models")
+    run_command(f"./run.sh {architecture}/runq md/model.bin md/data/test/*/*")
+
+if __name__ == "__main__":
+    architecture = sys.argv[1]
+    main(architecture)


### PR DESCRIPTION
The Github Actions tests all inferences (except arm64) run successfully. The tests for arm64 inferences is not implemented, since Github doesn't support linux/arm64 on which inferences are compiled.

Related to https://github.com/ninjalabo/tinyMLaaS/issues/71