### PR TITLE
update inference to use fastai learner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ name: inference-test
 
 on:
   push:
-  pull_request:
-    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 jobs:

--- a/md/runtime_info.json
+++ b/md/runtime_info.json
@@ -4,8 +4,8 @@
   "image": "",
   "compression": {
     "quantization": {
-	"type": "dynamic",
-	"asymmetric": true
+      "type": "dynamic",
+      "asymmetric": true
     },
     "pruning": 0
   },


### PR DESCRIPTION
By this change, pytorch inference should parallellize image reading, which was not parallelized before. This was bottleneck in arm, so it should give slightly higher performance.